### PR TITLE
Declare property blockparents

### DIFF
--- a/HTML/Template/IT.php
+++ b/HTML/Template/IT.php
@@ -272,6 +272,13 @@ class HTML_Template_IT
     var $blockinner = array();
 
     /**
+     * Array of parent block of a block.
+     * @var      array
+     * @access   private
+     */
+    var $blockparents = array();
+
+    /**
      * List of blocks to preverse even if they are "empty".
      *
      * This is something special. Sometimes you have blocks that


### PR DESCRIPTION
Phpunit is complaining about the dynamic creation of a property.

vendor/pear/html_template_it/HTML/Template/IT.php:1098
Creation of dynamic property HTML_Template_IT::$blockparents is deprecated

This will fix this issue.